### PR TITLE
cmake: improve robustness of add_pkg

### DIFF
--- a/vars/PKGBUILD
+++ b/vars/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ps4-openorbis-vars
 pkgver=1.0.0
-pkgrel=17
+pkgrel=18
 pkgdesc='helper scripts to set variables for ps4 toolchain'
 arch=('any')
 url='https://github.com/PacBrew'
@@ -12,7 +12,7 @@ groups=('ps4-openorbis')
 
 sha256sums=(
   '7fbdf48fe6279db6e385a92116d3d9ec574b9945e71bd12c7addeb5200a2356c' # ps4vars.sh
-  '34d5916bdf169327f55ecb75f65a127b5532235183e6a03b07082fe91804f06f' # ps4.cmake
+  'f4ee49cec499fee5ba4fb9b2ee87c187ff5d0a5d6dde35eb4577bc1886b4e3d1' # ps4.cmake
   '0a32ce4e9a41e91df50e036f9f22b2aafac2778ae8286b8b7fc84fafb38aa38a' # openorbis-cmake
 )
 

--- a/vars/ps4.cmake
+++ b/vars/ps4.cmake
@@ -114,7 +114,7 @@ endfunction()
 
 function(add_pkg project pkgdir title-id title version)
     string(SUBSTRING "${title}" 0 127 title)
-    string(SUBSTRING "${version}" 0 7 title)
+    string(SUBSTRING "${version}" 0 7 version)
     string(MAKE_C_IDENTIFIER "${version}" verclean)
     string(REPLACE "_" "0" verclean ${verclean})
     string(TOUPPER "${verclean}" verclean)

--- a/vars/ps4.cmake
+++ b/vars/ps4.cmake
@@ -113,7 +113,15 @@ function(add_self project)
 endfunction()
 
 function(add_pkg project pkgdir title-id title version)
-    string(REPLACE "." "" verclean ${version})
+    string(SUBSTRING "${title}" 0 127 title)
+    string(SUBSTRING "${version}" 0 7 title)
+    string(MAKE_C_IDENTIFIER "${version}" verclean)
+    string(REPLACE "_" "0" verclean ${verclean})
+    string(TOUPPER "${verclean}" verclean)
+    string(APPEND verclean "00000000")
+    string(SUBSTRING "${verclean}" 0 7 verclean)
+    set(content_id "IV0001-${title-id}_00-${title-id}${verclean}")
+  
     add_custom_command(
             OUTPUT "${project}.pkg"
             # copy required files to binary directory
@@ -125,14 +133,14 @@ function(add_pkg project pkgdir title-id title version)
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo ATTRIBUTE --type Integer --maxsize 4 --value 0
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo CATEGORY --type Utf8 --maxsize 4 --value "gde"
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo FORMAT --type Utf8 --maxsize 4 --value "obs"
-            COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo CONTENT_ID --type Utf8 --maxsize 48 --value "IV0001-${title-id}_00-${title-id}000${verclean}"
+            COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo CONTENT_ID --type Utf8 --maxsize 48 --value "${content_id}"
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo DOWNLOAD_DATA_SIZE --type Integer --maxsize 4 --value 0
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo SYSTEM_VER --type Integer --maxsize 4 --value 1020
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo TITLE --type Utf8 --maxsize 128 --value "${title}"
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo TITLE_ID --type Utf8 --maxsize 12 --value "${title-id}"
             COMMAND "${OPENORBIS}/bin/linux/PkgTool.Core" sfo_setentry ${pkgdir}/sce_sys/param.sfo VERSION --type Utf8 --maxsize 8 --value "${version}"
             # generate gp4 file
-            COMMAND "${OPENORBIS}/bin/linux/create-gp4" -out ${pkgdir}/${project}.gp4 --content-id "IV0001-${title-id}_00-${title-id}000${verclean}" --path "${pkgdir}"
+            COMMAND "${OPENORBIS}/bin/linux/create-gp4" -out ${pkgdir}/${project}.gp4 --content-id "${content_id}" --path "${pkgdir}"
             # generate pkg
             COMMAND cd ${pkgdir} && "${OPENORBIS}/bin/linux/PkgTool.Core" pkg_build ${project}.gp4 ${CMAKE_BINARY_DIR}
             # cleanup


### PR DESCRIPTION
improve robustness of add_pkg by filtering out illegal characters from parameter values